### PR TITLE
return defauldt Provider for Share_Type_Remote_Group

### DIFF
--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -130,7 +130,8 @@ class ProviderFactory implements IProviderFactory {
 			$shareType === \OCP\Share::SHARE_TYPE_GROUP ||
 			$shareType === \OCP\Share::SHARE_TYPE_LINK) {
 			$provider = $this->defaultShareProvider();
-		} elseif ($shareType === \OCP\Share::SHARE_TYPE_REMOTE) {
+		} elseif ($shareType === \OCP\Share::SHARE_TYPE_REMOTE ||
+			$shareType === \OCP\Share::SHARE_TYPE_REMOTE_GROUP) {
 			$provider = $this->federatedShareProvider();
 		}
 


### PR DESCRIPTION
set a default share provider for SHARE_TYPE_REMOTE_GROUP

## Related Issue
https://github.com/pondersource/oc-opencloudmesh/issues/19

## Motivation and Context
federated groups and opencloudmeshapplication
